### PR TITLE
chore(deps): replace github.com/simple-icons/simple-icons with github…

### DIFF
--- a/vendors/simple-icons/config.toml
+++ b/vendors/simple-icons/config.toml
@@ -2,7 +2,7 @@
 path = "github.com/razonyang/hugo-mod-icons"
 
 [[module.imports]]
-path = "github.com/simple-icons/simple-icons"
+path = "github.com/razonyang/simple-icons"
 ignoreConfig = true
 [[module.imports.mounts]]
 source = "icons"

--- a/vendors/simple-icons/go.mod
+++ b/vendors/simple-icons/go.mod
@@ -3,6 +3,6 @@ module github.com/razonyang/hugo-mod-icons/vendors/simple-icons
 go 1.18
 
 require (
-	github.com/razonyang/hugo-mod-icons v0.2.0 // indirect
-	github.com/simple-icons/simple-icons v0.0.0-20221211155417-72095f401874 // indirect
+	github.com/razonyang/hugo-mod-icons v0.3.0 // indirect
+	github.com/razonyang/simple-icons v8.4.0+incompatible // indirect
 )

--- a/vendors/simple-icons/go.sum
+++ b/vendors/simple-icons/go.sum
@@ -1,4 +1,4 @@
-github.com/razonyang/hugo-mod-icons v0.2.0 h1:xEeFV2bZnimG5KH+l0yWWYtq9doJODBM/IpX6DVB8xY=
-github.com/razonyang/hugo-mod-icons v0.2.0/go.mod h1:4atUyrOOKz1CnywT6qdUy3KoK4hcsM/JnS/EvqDWgnY=
-github.com/simple-icons/simple-icons v0.0.0-20221211155417-72095f401874 h1:aA4Imk8JdudoWa/9fxKCGJCb1yEhUYca2NMtQGkkQzk=
-github.com/simple-icons/simple-icons v0.0.0-20221211155417-72095f401874/go.mod h1:oOgUUt8yVYOso/wEBi2ojfZP2MU/xxiNccIpaE+jCvE=
+github.com/razonyang/hugo-mod-icons v0.3.0 h1:z9kgC00LDV4QPlK6QgIW8E/iALvuoUW/tIEhlgg+D3w=
+github.com/razonyang/hugo-mod-icons v0.3.0/go.mod h1:4atUyrOOKz1CnywT6qdUy3KoK4hcsM/JnS/EvqDWgnY=
+github.com/razonyang/simple-icons v8.4.0+incompatible h1:nJk23BXY4shAz5Go/OnM5zdNyEFeVqkt1ZjZ8vGpPsM=
+github.com/razonyang/simple-icons v8.4.0+incompatible/go.mod h1:wQqQhbcK5GWujo4xzio0cQMufqwFVjjU+g3TwHd2iYU=


### PR DESCRIPTION
….com/razonyang/simple-icons

Since the upstream repo has two types of releases: with and without prefix `v`, it'll be a problem when using `hugo mod tidy`, the prefixed release will be keep, that is, it's unable to upgrade to the latest releases without prefix `v`.